### PR TITLE
JSON mapping http endpoint to shell script!

### DIFF
--- a/app/http_server.js
+++ b/app/http_server.js
@@ -1,31 +1,34 @@
 var app = require('express')();
 var execProcess = require("../app/exec_process.js");
 var port = process.env.PORT || 3000;
+var httpJson = require('../config/http.json');
 
 app.get("/", function(req, res){
 	res.send("Server configured.");
 });
 
-app.get("/test-exec", function(req, res){
-	execProcess.result("sh shell_scripts/temp.sh", function(err, response){
-		if(!err){
-			res.send(response);
-		}else {
-			res.send("Error: ", err);
-		}
-	});
+/**
+ * Convert JSON to Array
+ */
+var httpArr = Object.keys(httpJson).map(function(k){
+	return httpJson[k];
 });
 
-app.get("/exec", function(req, res){
-	execProcess.result("sh shell_scripts/tail_logs.sh", function(err, response){
-		if(!err){
-			res.send(response);
-		}else {
-			res.send("Error: ", err);
-		}
+/**
+ * Prepare http enpoints looping through array items
+ * Map http enpoint to a shell script
+ */
+httpArr.map(function(o){
+	app.get(o["url"], function(req, res){
+		execProcess.result(o["cmd"], function(err, response){
+			if(!err){
+				res.send(response);
+			}else {
+				res.send("Error: ", err);
+			}
+		});
 	});
-});
+})
 
-// var http = app.listen(3000);
 var http = app.listen(port);
 exports.http = http;

--- a/config/http.json
+++ b/config/http.json
@@ -1,0 +1,10 @@
+{
+    "test-exec": {
+        "url": "/test-exec",
+        "cmd": "sh shell_scripts/temp.sh"
+    },
+    "exec": {
+        "url": "/exec",
+        "cmd": "sh shell_scripts/tail_logs.sh"
+    }
+}


### PR DESCRIPTION
## Config JSON for http => shell script

Introducing json file for mapping http enpoint to shell script. Easy to configure and get rid of repetitive http  get end point codes using express
### Configuration

config/http.json
- url refers to http endpoint
- cmd refers to shell script to be executed

``` json
{
    "test-exec": {
        "url": "/test-exec",
        "cmd": "sh shell_scripts/temp.sh"
    },
    "exec": {
        "url": "/exec",
        "cmd": "sh shell_scripts/tail_logs.sh"
    }
}
```

So, for configuring any new end point, we need to add the respective values in `config/http.json`. No changes required in express http server. 
### Todo
- [x] Existing work flow ported to new http.json
- [x] All test passing
- [ ] Update README.md
